### PR TITLE
Update to chrome-aws-lambda@2.0.1

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-LIB_VERSION=2.0.0
+LIB_VERSION=2.0.1
 CHROMIUM_VERSION=79.0.3945.0
 LAYER_NAME='chrome-aws-lambda'
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ ARN" and enter the following ARN.
 arn:aws:lambda:us-east-1:764866452798:layer:chrome-aws-lambda:8
 ```
 
-Current version: chrome-aws-lambda v2.0.0 & Chromium v79.0.3945.0
+Current version: chrome-aws-lambda v2.0.1 & Chromium v79.0.3945.0
 
 ## Available regions
 


### PR DESCRIPTION
It would be great to get a new version of this published with `chrome-aws-lambda@2.0.1` because it adds support for the new `nodejs12.x` Lambda runtime.

https://github.com/alixaxel/chrome-aws-lambda/compare/v2.0.0...v2.0.1

I've followed the steps in the readme to update `chrome_aws_lambda.zip`. Please let me know if there's anything else I should do.