### PR TITLE
Update Layer to use @sparticuz/chromium

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.js text eol=lf
 *.zip filter=lfs diff=lfs merge=lfs -text
 chrome_aws_lambda.zip filter=lfs diff=lfs merge=lfs -text
+chromium.zip filter=lfs diff=lfs merge=lfs -text

--- a/chrome_aws_lambda.zip
+++ b/chrome_aws_lambda.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b3ec7b78f4a42da374c941d698d7a4d0b4e2a691ffeb0b30abe6a7eb8e5fe0dc
-size 52920758

--- a/chromium.zip
+++ b/chromium.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:673896c4cb515338e790a848b83a7e2db403709fc14626be65235d7fdc05431b
+size 58118848

--- a/create-zip.sh
+++ b/create-zip.sh
@@ -1,4 +1,4 @@
-unzip chrome_aws_lambda.zip
+unzip chromium.zip
 
 npx del-cli "nodejs/node_modules/**/@types/**" \
   "nodejs/node_modules/**/*.d.ts" \
@@ -10,5 +10,5 @@ npx del-cli "nodejs/node_modules/**/@types/**" \
   "nodejs/node_modules/agent-base/src/*.ts" \
   "nodejs/**/.DS_Store"
 
-rm chrome_aws_lambda.zip
-zip -r chrome_aws_lambda.zip -9 nodejs
+rm chromium.zip
+zip -r chromium.zip -9 nodejs

--- a/publish.sh
+++ b/publish.sh
@@ -9,8 +9,8 @@ LAYER_DESCRIPTION="@sparticuz/chromium v${LIB_VERSION} & Chromium v${CHROMIUM_VE
 S3_BUCKET_NAME=shelf-lambda-layers-"$TARGET_REGION"
 
 aws s3 cp \
-  /home/circleci/project/chrome_aws_lambda.zip \
-  s3://"$S3_BUCKET_NAME"/chrome_aws_lambda.zip
+  /home/circleci/project/chromium.zip \
+  s3://"$S3_BUCKET_NAME"/chromium.zip
 
 aws lambda add-layer-version-permission \
   --region "$TARGET_REGION" \
@@ -25,5 +25,5 @@ aws lambda add-layer-version-permission \
       --description "$LAYER_DESCRIPTION" \
       --query Version \
       --output text \
-      --content S3Bucket="$S3_BUCKET_NAME",S3Key=chrome_aws_lambda.zip
+      --content S3Bucket="$S3_BUCKET_NAME",S3Key=chromium.zip
   )"

--- a/publish.sh
+++ b/publish.sh
@@ -2,10 +2,10 @@
 
 aws configure set default.region "$TARGET_REGION" --profile default
 
-LIB_VERSION=14.3.0
-CHROMIUM_VERSION=103.0.5058.0
+LIB_VERSION=109.0.0
+CHROMIUM_VERSION=109.0.0.0
 LAYER_NAME='chrome-aws-lambda'
-LAYER_DESCRIPTION="@sparticuz/chrome-aws-lambda v${LIB_VERSION} & Chromium v${CHROMIUM_VERSION}"
+LAYER_DESCRIPTION="@sparticuz/chromium v${LIB_VERSION} & Chromium v${CHROMIUM_VERSION}"
 S3_BUCKET_NAME=shelf-lambda-layers-"$TARGET_REGION"
 
 aws s3 cp \

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 # Google Chrome for AWS Lambda as a layer
 
-> 53 MB Google Chrome to fit inside AWS Lambda Layer compressed with Brotli
+> 58 MB Google Chrome to fit inside AWS Lambda Layer compressed with Brotli
 
-[chrome-aws-lambda](https://github.com/Sparticuz/chrome-aws-lambda) published as a Lambda Layer.
+[Sparticuz/chromium](https://github.com/Sparticuz/chromium) published as a Lambda Layer.
 
-Works with Node.js 16x. Has Chromium v103.0.5058.0.
+Works with Node.js 16x. Has Chromium v109.0.0.0.
 
 ## Getting Started
 
@@ -15,12 +15,12 @@ ARN" and enter the following ARN.
 arn:aws:lambda:us-east-1:764866452798:layer:chrome-aws-lambda:31
 ```
 
-Current version: `@sparticuz/chrome-aws-lambda` v14.3.0 & Chromium v103.0.5058.0
+Current version: `@sparticuz/chrome-aws-lambda` & Chromium v109.0.0
 
-When importing the module within lambda, make sure you import `@sparticuz/chrome-aws-lambda` not `chrome-aws-lambda`
+When importing the module within lambda, make sure you import `@sparticuz/chromium` not `chrome-aws-lambda`
 
-```
-const chromium = require("@sparticuz/chrome-aws-lambda");
+```js
+const chromium = require('@sparticuz/chromium');
 ```
 
 ## Available regions

--- a/readme.md
+++ b/readme.md
@@ -45,8 +45,8 @@ const chromium = require("@sparticuz/chrome-aws-lambda");
 
 ## Update
 
-1. Grab the latest artifact from https://github.com/Sparticuz/chrome-aws-lambda/actions/workflows/aws.yml?query=branch%3Amaster
-2. Copy `chrome_aws_lambda.zip` to this repo
+1. Grab the latest artifact from https://github.com/Sparticuz/chromium/actions/workflows/aws.yml
+2. Copy `chromium.zip` to this repo
 3. Run `create-zip.sh` to reduce the zip size
 4. Put proper version inside `publish.sh` & `README.md` (append `[ci skip]` suffix to the commit message to avoid republishing)
 5. Push


### PR DESCRIPTION
Updates the project to use `@sparticuz/chromium` instead of `@sparticuz/chrome-aws-lambda`.
Chromium itself has also been updated to v109.
This should fix #53.

I've deployed the layer to my own AWS account and could confirm that everything still works as intended.

(I've renamed `chrome_aws_lambda.zip` to `chromium.zip`, as the artifcat name in `Sparticuz/chromium` also [changed](https://github.com/Sparticuz/chromium/actions/runs/3642995056).) 