### PR TITLE
fix: architecture selection in layer dispatch workflow

### DIFF
--- a/.github/workflows/layers_dispatch.yaml
+++ b/.github/workflows/layers_dispatch.yaml
@@ -34,7 +34,7 @@ jobs:
         id: latest_release
         run: |
           JSON_RESPONSE=$(curl -s https://api.github.com/repos/Sparticuz/chromium/releases/latest)
-          LATEST_RELEASE_URL=$(echo $JSON_RESPONSE | grep -Po '"browser_download_url": "\K[^"]+' | awk 'NR==1')
+          LATEST_RELEASE_URL=$(echo $JSON_RESPONSE | grep -Po '"browser_download_url": "\K[^"]+x64\.zip' | awk 'NR==1')
           TAG_VERSION=$(echo $JSON_RESPONSE | grep -Po '"tag_name": "\K[^"]+')
           if [[ "$TAG_VERSION" == "${{ steps.prev_tag_version.outputs.tag }}" ]]; then
             echo "Skipping as the tag version is the same as the previous run."


### PR DESCRIPTION
Previously, the workflow was downloading ARM64 binaries instead of x86_64, as reported in issue #72. This change updates the regex pattern to specifically select the x64.zip file from the GitHub release assets, ensuring the correct architecture is used for the Lambda layer.

```shell
$ JSON_RESPONSE=$(curl -s https://api.github.com/repos/Sparticuz/chromium/releases/latest)

# Previous
$  echo $JSON_RESPONSE | grep -Po '"browser_download_url": "\K[^"]+' 
https://github.com/Sparticuz/chromium/releases/download/v141.0.0/chromium-v141.0.0-layer.arm64.zip
https://github.com/Sparticuz/chromium/releases/download/v141.0.0/chromium-v141.0.0-layer.x64.zip
https://github.com/Sparticuz/chromium/releases/download/v141.0.0/chromium-v141.0.0-pack.arm64.tar
https://github.com/Sparticuz/chromium/releases/download/v141.0.0/chromium-v141.0.0-pack.x64.tar

# FIxed
$  echo $JSON_RESPONSE | grep -Po '"browser_download_url": "\K[^"]+x64\.zip'
https://github.com/Sparticuz/chromium/releases/download/v141.0.0/chromium-v141.0.0-layer.x64.zip
```